### PR TITLE
Front filtrar produto por nome

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,6 +27,7 @@
 
     <!-- SCRIPTS -->
     <script src="/public/scripts/popupConfirmar.js" defer></script>
+    <script src="/public/scripts/buscarProduto.js" defer></script>
 </head>
 <body>
     <nav class="nav">

--- a/public/scripts/buscarProduto.js
+++ b/public/scripts/buscarProduto.js
@@ -7,15 +7,23 @@ inputBuscar.addEventListener("keyup", () => {
 
     const buscaRegex = new RegExp(buscaStr, 'i')
 
-    if (buscaStr == "") {
+    
+    if (buscaStr == "" || !buscaStr) {
         produtosView.forEach(produto => produto.classList.remove("cardProduto--hidden"))
         return
     }
+
+    console.log(buscaRegex)
 
     produtosView.forEach(produto => {
         const nome = produto.querySelector("h3").textContent
         if (!buscaRegex.test(nome)) {
             produto.classList.add("cardProduto--hidden")
+        } else {
+            produto.classList.remove("cardProduto--hidden")
+
         }
     })
+
+    console.log(inputBuscar.value)
 })

--- a/public/scripts/buscarProduto.js
+++ b/public/scripts/buscarProduto.js
@@ -1,0 +1,21 @@
+const produtosView = document.querySelectorAll("body > main > ul > li")
+
+const inputBuscar = document.querySelector("body > main > header > div.form__input__container > input")
+
+inputBuscar.addEventListener("keyup", () => {
+    const buscaStr = inputBuscar.value.trim()
+
+    const buscaRegex = new RegExp(buscaStr, 'i')
+
+    if (buscaStr == "") {
+        produtosView.forEach(produto => produto.classList.remove("cardProduto--hidden"))
+        return
+    }
+
+    produtosView.forEach(produto => {
+        const nome = produto.querySelector("h3").textContent
+        if (!buscaRegex.test(nome)) {
+            produto.classList.add("cardProduto--hidden")
+        }
+    })
+})

--- a/public/scripts/buscarProduto.js
+++ b/public/scripts/buscarProduto.js
@@ -13,8 +13,6 @@ inputBuscar.addEventListener("keyup", () => {
         return
     }
 
-    console.log(buscaRegex)
-
     produtosView.forEach(produto => {
         const nome = produto.querySelector("h3").textContent
         if (!buscaRegex.test(nome)) {
@@ -24,6 +22,5 @@ inputBuscar.addEventListener("keyup", () => {
 
         }
     })
-
-    console.log(inputBuscar.value)
+    
 })

--- a/styles/cards/produto/produto.css
+++ b/styles/cards/produto/produto.css
@@ -8,6 +8,10 @@
     height: 450px;
 }
 
+.cardProduto--hidden {
+    display: none;
+}
+
 .cardProduto { transition: all .3s ease-in-out; }
 .cardProduto:hover { transform: scale(1.05); }
 


### PR DESCRIPTION
Filtra os produtos na tela de acordo com o busca. Ignora letras maísculas/minúsculas. Quando não há resultado para a busca, não mostra produtos na tela.